### PR TITLE
fix: prevent section-link stretching in flex/grid containers

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -425,6 +425,7 @@ footer {
    vs. section-closing links. */
 .section-link {
 	display: inline-block;
+	place-self: start;
 	margin-top: 1.5rem;
 	font-size: 0.95rem;
 	font-weight: 500;


### PR DESCRIPTION
## What changed and why
Fixed `.section-link` underlines stretching to full container width on homepage and tag archive pages. The issue occurred because `display: inline-block` gets overridden by flex/grid parent containers, causing the `border-bottom` underline to span the full cross-axis width instead of just the text width. Added `place-self: start` to prevent this stretching behavior.

## What I considered and rejected
Could have used `width: max-content` instead of `place-self: start`, but place-self is more explicit about the layout intent and works consistently across both flex and grid contexts without side effects on the element's intrinsic sizing.

## Where to look first
`static/css/main.css:428` — the added `place-self: start` property in the `.section-link` rule.

## What I'm unsure about
Fully confident because place-self is the standard CSS property for controlling item alignment in both flex and grid containers, and the fix addresses exactly the described problem without affecting other layout contexts.

## How I verified
Manually tested on dev server at http://localhost:8080: homepage "View all posts →" underline now matches text width, tag pages "View all tags →" underline matches text width, `/now/` "Previously →" remains unchanged.

## Dock task
http://localhost:3000/tasks/58