### PR TITLE
feat: style /tags/ page with tag chips in wrapping flex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -481,7 +481,6 @@
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -579,7 +578,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
 			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -620,7 +618,6 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -667,7 +664,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
 			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -683,7 +679,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
 			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
 				"@babel/helper-validator-option": "^7.23.5",
@@ -700,7 +695,6 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
 			}
@@ -710,7 +704,6 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -719,15 +712,13 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@babel/helper-environment-visitor": {
 			"version": "7.22.20",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
 			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -737,7 +728,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
 			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
 				"@babel/types": "^7.23.0"
@@ -751,7 +741,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
 			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.22.5"
 			},
@@ -764,7 +753,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
 			"integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.22.15"
 			},
@@ -777,7 +765,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
 			"integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-module-imports": "^7.22.15",
@@ -807,7 +794,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
 			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.22.5"
 			},
@@ -820,7 +806,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
 			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/types": "^7.22.5"
 			},
@@ -833,7 +818,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
 			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -852,7 +836,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
 			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -862,7 +845,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
 			"integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
 				"@babel/traverse": "^7.23.6",
@@ -962,7 +944,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
 			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -991,7 +972,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
 			"integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.22.13",
 				"@babel/parser": "^7.22.15",
@@ -1006,7 +986,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
 			"integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
 				"@babel/generator": "^7.23.6",
@@ -1028,7 +1007,6 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -1038,7 +1016,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
 			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -1064,6 +1041,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1087,6 +1065,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -1381,7 +1360,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1396,7 +1374,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1406,7 +1383,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -1415,15 +1391,13 @@
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.20",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
 			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1597,6 +1571,7 @@
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1992,8 +1967,7 @@
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
-			],
-			"peer": true
+			]
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
@@ -2178,8 +2152,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/cosmiconfig": {
 			"version": "9.0.0",
@@ -2513,8 +2486,7 @@
 			"version": "1.4.616",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz",
 			"integrity": "sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/eleventy-plugin-svg-contents": {
 			"version": "0.7.0",
@@ -2680,7 +2652,6 @@
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2710,6 +2681,7 @@
 			"integrity": "sha512-KjeihdFqTPhOMXTt7StsDxriV4n66ueuF/jfPNC3j/lduHwr/ijDwJMsF+wyMJethgiKi5wniIE243vi07d3pg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3302,7 +3274,6 @@
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -4206,7 +4177,6 @@
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -4245,7 +4215,6 @@
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -4858,8 +4827,7 @@
 			"version": "2.0.14",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
-			"dev": true,
-			"peer": true
+			"dev": true
 		},
 		"node_modules/node-retrieve-globals": {
 			"version": "6.0.0",
@@ -5464,6 +5432,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.8",
 				"picocolors": "^1.1.1",
@@ -5532,6 +5501,7 @@
 			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
 			"integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"posthtml-parser": "^0.11.0",
 				"posthtml-render": "^3.0.0"
@@ -6695,6 +6665,7 @@
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -6894,7 +6865,6 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
 			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -6998,7 +6968,6 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
-			"peer": true,
 			"dependencies": {
 				"escalade": "^3.1.1",
 				"picocolors": "^1.0.0"

--- a/site/tags.njk
+++ b/site/tags.njk
@@ -1,12 +1,22 @@
 ---
 title: Tags
-layout: page
+layout: base
 ---
-<ul>
-{% for tag in collections.tagList %}
-	<li>
-  	<a href="/tags/{{ tag | slugify }}">{{ tag }}</a>
-		({{ collections[tag].length }})
-	</li>
-{% endfor %}
-</ul>
+<div class="page-header section-grid">
+  <div class="section-label"></div>
+  <div>
+    <h1 class="page-title">Tags</h1>
+    <p class="subtitle">{{ collections.tagList | length }} tags across the archive.</p>
+  </div>
+</div>
+
+{% include "partials/divider.njk" %}
+
+<section class="section-grid">
+  <div class="section-label"></div>
+  <div class="tag-bar">
+    {% for tag in collections.tagList %}
+      <a href="/tags/{{ tag | slugify }}/" class="tag-chip">{{ tag }} {{ collections[tag].length }}</a>
+    {% endfor %}
+  </div>
+</section>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -413,6 +413,14 @@ footer {
 	color: var(--white);
 }
 
+/* Tag Bar - flexbox container for tag chips */
+.tag-bar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	align-items: center;
+}
+
 /* Section link — the standardized "continue / view more / previous" affordance.
    Used on: homepage "View all posts", tag pages "View all tags",
    now-page "Previously", post prev/next pagers. Lives inside a

--- a/static/css/posts.css
+++ b/static/css/posts.css
@@ -81,14 +81,6 @@
 	padding-bottom: 4rem;
 }
 
-/* ─── 9. Tag filter band ─── */
-.tag-bar {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 0.5rem;
-	align-items: center;
-}
-
 .tag-more {
 	font-size: 0.75rem;
 	font-weight: 500;

--- a/static/design-system.html
+++ b/static/design-system.html
@@ -1270,7 +1270,7 @@
 					<div class="sb-story" id="cmp-tag-filter">
 						<div class="sb-story-head">
 							<h3>Tag filter band</h3>
-							<span class="sb-meta">.tag-bar + .tag-more (posts.css)</span>
+							<span class="sb-meta">.tag-bar + .tag-more (main.css)</span>
 						</div>
 						<div class="sb-story-desc">
 							Top-popular chips inline; "+N more" reveals the full cloud (0.3s


### PR DESCRIPTION
## What changed and why
Redesigned the `/tags/` page from an unstyled list to a proper content page with tag chips. The old page was a bare `<ul>` that ignored max-width constraints and had no page header, making it look broken compared to other site pages. Rewrote the template to use the standard page-header + section-grid pattern and display tags as horizontal wrapping chips with post counts.

## What I considered and rejected
Could have kept the list format and just styled it, but the chip layout is more consistent with how tags appear elsewhere on the site (homepage, post listings) and provides better visual hierarchy with the proper page header.

## Where to look first
`site/tags.njk` — complete rewrite using page-header + section-grid pattern with tag-bar of tag-chips, and `static/css/main.css:418` — the moved `.tag-bar` flexbox layout rule.

## What I'm unsure about
Fully confident — this follows the established design system patterns exactly as used on other content pages, and moves shared CSS to the appropriate location.

## How I verified
Manual testing on dev server at http://localhost:8081/tags — page now has proper header, tag chips wrap properly, respects max-width, and clicking chips navigates correctly to tag archives.

## Dock task
http://localhost:3000/tasks/63