### PR TITLE
feat: add consistent vertical spacing to section-grid

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -198,6 +198,7 @@ h4 {
 	max-width: var(--max-width);
 	margin: 0 auto;
 	padding: 0 var(--page-padding);
+	padding-block: 2rem;
 }
 
 .section-label {


### PR DESCRIPTION
## What changed and why
Added `padding-block: 2rem` to `.section-grid` to create consistent vertical breathing room across content pages. Previously, Uses felt spacious due to prose margins while Now/Colophon felt cramped with row-based content that had no trailing margins.

## What I considered and rejected
Could have added spacing to individual content types, but adding it to the container ensures consistency across all section-grid usage regardless of content type. This is more maintainable than per-content-type margin adjustments.

## Where to look first
`static/css/main.css:201` — the added `padding-block: 2rem;` property in the `.section-grid` rule.

## What I'm unsure about
Fully confident — this approach provides consistent baseline spacing while allowing existing overrides (page-header, year-group) to maintain their specific spacing requirements.

## How I verified
Manual testing on dev server at http://localhost:8082 — checked Uses, Now, and Colophon pages for consistent section rhythm. Confirmed post archive and homepage remain unchanged due to existing overrides.

## Dock task
http://localhost:3000/tasks/59