### PR TITLE
fix: move section-link bottom spacing rule to main.css

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -441,6 +441,11 @@ footer {
 	text-decoration: none;
 }
 
+/* Section link footer spacing */
+.section-grid:has(.section-link) {
+	padding-bottom: 4rem;
+}
+
 /* ─── 15. Mobile-first Responsive (DSYS-09) ─── */
 
 /* Mobile base styles (default) */

--- a/static/css/posts.css
+++ b/static/css/posts.css
@@ -76,10 +76,6 @@
 	flex-shrink: 0;
 }
 
-/* ─── 8. Section link footer spacing ─── */
-.section-grid:has(.section-link) {
-	padding-bottom: 4rem;
-}
 
 /* ─── 9. Tag filter band ─── */
 .tag-bar {


### PR DESCRIPTION
## What changed and why
Moved the `.section-grid:has(.section-link)` rule from posts.css to main.css so it applies universally to all pages with section-links. The /now/ page was missing 4rem bottom spacing because it loads content-pages.css instead of posts.css where this rule originally lived.

## What I considered and rejected
Could have added the rule to content-pages.css instead, but main.css is the better location since this spacing should apply anywhere section-links appear, regardless of which page-specific CSS is loaded.

## Where to look first
`static/css/main.css:446` — the moved `.section-grid:has(.section-link)` rule, and `static/css/posts.css:80` — where the rule was removed from.

## What I'm unsure about
Fully confident — this is a straightforward rule relocation to make universal spacing behavior work correctly across all page types.

## How I verified
Rule moved without modification, so existing functionality on /posts/ remains unchanged while /now/ page now gets the missing spacing.

## Dock task
http://localhost:3000/tasks/60