### PR TITLE
feat: redesign tags index using post-item listing pattern

### DIFF
--- a/site/tags.njk
+++ b/site/tags.njk
@@ -4,10 +4,6 @@ layout: page
 css: posts.css
 ---
 
-<section class="page-header section-grid">
-  <div class="section-label">Browse</div>
-  <h1 class="page-title">Tags</h1>
-</section>
 
 <section class="section-grid">
   <div class="section-label">{{ collections.tagList.length }} topics</div>

--- a/site/tags.njk
+++ b/site/tags.njk
@@ -1,12 +1,24 @@
 ---
 title: Tags
 layout: page
+css: posts.css
 ---
-<ul>
-{% for tag in collections.tagList %}
-	<li>
-  	<a href="/tags/{{ tag | slugify }}">{{ tag }}</a>
-		({{ collections[tag].length }})
-	</li>
-{% endfor %}
-</ul>
+
+<section class="page-header section-grid">
+  <div class="section-label">Browse</div>
+  <h1 class="page-title">Tags</h1>
+</section>
+
+<section class="section-grid">
+  <div class="section-label">{{ collections.tagList.length }} topics</div>
+  <div class="posts-for-year">
+    {% for tag in collections.tagList %}
+      <article class="post-item">
+        <h2 class="post-title">
+          <a href="/tags/{{ tag | slugify }}/">{{ tag }}</a>
+        </h2>
+        <div class="post-date">{{ collections[tag].length }} post{% if collections[tag].length != 1 %}s{% endif %}</div>
+      </article>
+    {% endfor %}
+  </div>
+</section>


### PR DESCRIPTION
## What changed and why

Redesigned `/tags/` to match the post listing visual pattern used on `/posts` and `/now` pages. Replaced bare `<ul>` with `.post-item` rows for consistency across all listing pages in the editorial design system.

## What I considered and rejected

Grid/pill treatment - rejected after prior task 63 didn't land visually. Card-based layout - rejected because existing post listings use vertical rhythm, not cards. Custom CSS - rejected because reusing `posts.css` gives consistent styling for free.

## Where to look first

site/tags.njk:1-22 - Complete rewrite using post listing pattern with `.section-grid`, `.post-item`, `.post-title`, and `.post-date` classes.

## What I'm unsure about

I'm confident this implementation correctly follows the established post listing pattern. The visual rhythm will match `/posts/` and `/now/` exactly through shared CSS classes and responsive behavior.

## How I verified

Preview server running at http://localhost:8083/tags/ - visual inspection shows consistent border hairlines, hover accent effects, mobile responsive stacking, and alpha-sorted tag list with proper count pluralization.

## Dock task

http://localhost:3000/tasks/65