### PR TITLE
fix: exclude empty now index page from RSS feed

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -113,7 +113,9 @@ export default async function (eleventyConfig) {
 	eleventyConfig.addCollection('feed', collectionApi =>
 		[
 			...collectionApi.getFilteredByTag('post'),
-			...collectionApi.getFilteredByTag('now'),
+			...collectionApi
+				.getFilteredByTag('now')
+				.filter(item => item.page.url !== '/now/'),
 		].sort((a, b) => a.date - b.date)
 	)
 


### PR DESCRIPTION
## What changed and why
The RSS feed was showing a blank entry titled "What I'm Doing Now" as the first item. This was caused by the empty `/now/index.njk` file being included in the feed collection due to the blanket 'now' tag applied by `now.11tydata.js`.

This fix filters out the `/now/` permalink from the RSS feed collection while preserving all dated now entries with their full content.

## What I considered and rejected
- **Removing the 'now' tag from index**: Would break navigation and page organization
- **Adding content to index page**: Would require design decisions about what content to show  
- **Changing the tag system**: Would require broader changes to the now page architecture

Chosen approach: surgical filter to exclude only the problematic empty index while maintaining all existing functionality.

## Where to look first
`eleventy.config.js:116-118` - Added `.filter(item => item.page.url !== '/now/')` to the now collection in the feed

## What I'm unsure about
Fully confident - this is a targeted fix that only affects the RSS feed generation and doesn't impact any other site functionality.

## How I verified
- Built site successfully with `npm run build`
- Verified RSS feed at `_site/feed.xml` no longer contains empty "What I'm Doing Now" entry
- Confirmed dated now entries (Apr 23, Feb 9) still appear with full content
- RSS feed now starts with content-rich entries as expected
