### PR TITLE
Add fallback for failed webmention avatars

### DIFF
--- a/includes/facepile.njk
+++ b/includes/facepile.njk
@@ -2,16 +2,15 @@
 {% set extra = items.length - shown.length %}
 <div class="facepile">
   {% for item in shown %}
-  {% if item.author and item.author.photo %}
-  <a class="facepile-item" href="{{ item.url }}" target="_blank" rel="noopener noreferrer">
-    <img class="facepile-avatar" src="{{ item.author.photo }}" alt="{{ item.author.name }}" width="38" height="38" loading="lazy">
-  </a>
-  {% else %}
   {% set authorName = item.author.name if item.author and item.author.name else '?' %}
   {% set words = authorName.split(' ') %}
   {% set initials = words[0].charAt(0) + (words[1].charAt(0) if words.length > 1 else '') %}
-  <a class="facepile-item facepile-item--initials{{ ' facepile-item--alt' if loop.index0 % 2 else '' }}" href="{{ item.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ authorName }}">{{ initials }}</a>
-  {% endif %}
+  <a class="facepile-item facepile-item--initials{{ ' facepile-item--alt' if loop.index0 % 2 else '' }}" href="{{ item.url }}" target="_blank" rel="noopener noreferrer" aria-label="{{ authorName }}">
+    <span aria-hidden="true">{{ initials }}</span>
+    {% if item.author and item.author.photo %}
+    <img class="facepile-avatar" src="{{ item.author.photo }}" alt="" width="38" height="38" loading="lazy" onerror="this.remove()">
+    {% endif %}
+  </a>
   {% endfor %}
   {% if extra > 0 %}
   <span class="facepile-item facepile-more">+{{ extra }}</span>

--- a/includes/replies.njk
+++ b/includes/replies.njk
@@ -2,14 +2,15 @@
 {% for reply in replies %}
 <article id="webmention-{{ reply['wm-id'] }}" class="reply h-cite">
   <div class="reply-header">
-    {% if reply.author and reply.author.photo %}
-    <img class="reply-avatar u-photo" src="{{ reply.author.photo }}" alt="" width="40" height="40" loading="lazy">
-    {% else %}
     {% set replyName = reply.author.name if reply.author and reply.author.name else 'Anonymous' %}
     {% set replyWords = replyName.split(' ') %}
     {% set replyInitials = replyWords[0].charAt(0) + (replyWords[1].charAt(0) if replyWords.length > 1 else '') %}
-    <span class="reply-avatar reply-avatar--initials{{ ' reply-avatar--alt' if loop.index0 % 2 else '' }}">{{ replyInitials }}</span>
-    {% endif %}
+    <span class="reply-avatar reply-avatar--initials{{ ' reply-avatar--alt' if loop.index0 % 2 else '' }}">
+      <span aria-hidden="true">{{ replyInitials }}</span>
+      {% if reply.author and reply.author.photo %}
+      <img class="u-photo" src="{{ reply.author.photo }}" alt="" width="40" height="40" loading="lazy" onerror="this.remove()">
+      {% endif %}
+    </span>
     {% if reply.author %}
     <a class="p-author h-card reply-author" {% if reply.author.url %}href="{{ reply.author.url }}" {% elif reply.url %}href="{{ reply.url }}" {% endif %}target="_blank" rel="noopener noreferrer"><strong class="p-name">{{ reply.author.name }}</strong></a>
     {% else %}

--- a/static/css/prose.css
+++ b/static/css/prose.css
@@ -269,6 +269,7 @@
 	overflow: hidden;
 	display: grid;
 	place-items: center;
+	position: relative;
 }
 
 .facepile-item {
@@ -277,10 +278,13 @@
 	text-decoration: none;
 }
 
-.facepile-avatar {
+.facepile-avatar,
+.reply-avatar > img {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
+	position: absolute;
+	inset: 0;
 }
 
 .facepile-item--initials,


### PR DESCRIPTION
## Summary
- render author initials beneath each remote webmention avatar
- reveal the initials when a remote avatar image fails to load
- apply the same fallback to reply avatars

## Verification
- `npm run build`
- `npm run lint:ci`
- `npm run format -- --check`

The remote URLs were available during investigation, but they redirect from webmention.io to an external S3 bucket. This preserves a readable avatar when that request is unavailable.