### PR TITLE
Migrate syntax highlighting to MicroLighter

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -275,7 +275,6 @@ Vanilla custom element (`static/js/theme-toggle.js`), no shadow DOM, so it inher
 Known open items, not yet closed:
 
 - **Favicon / safari-pinned-tab** still carry Timetable-era artwork (`mask-icon` color `#B44D2D`). Needs an Affiche asset pass (train mark on cream). The `mask-icon` tint is coupled to the pinned-tab SVG's own shape, so it waits for that redraw; `msapplication-TileColor` was a standalone color value with no artwork of its own to redraw, so it was brought in line with the current palette directly. Marked with a `TODO(affiche)` comment in `layouts/base.njk`. The og:image half of this is done: `static/img/og-card.png` is a poster-frame social card whose editable source lives in the brand repo (`~/Projects/craveytrain/social/og-card.html`).
-- **Code-block syntax palette**: `--syntax-*` tokens in `static/css/main.css` are unchanged placeholders (marked `TODO(affiche)`), not yet re-derived from the midnight/red/gold/teal palette. `.post-content pre`/`.token.*` rules in `prose.css` still reference them as-is.
 - **Hero portrait/photo treatment** if it ever returns. No spec yet.
 - **Bebas letter-spacing tuning**: current values are eyeballed per size, worth a dedicated typography pass.
 - **Print styles** for posts. None exist; the frame should probably drop for print.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,7 +1,6 @@
 import fs from 'fs/promises'
 import eleventyNavigationPlugin from '@11ty/eleventy-navigation'
 import { feedPlugin } from '@11ty/eleventy-plugin-rss'
-import syntaxHighlight from '@11ty/eleventy-plugin-syntaxhighlight'
 import contentTags from './utils/content-tags.js'
 import groupByYearDesc from './utils/group-by-year.js'
 import tagList from './utils/tag-list.js'
@@ -49,6 +48,26 @@ export default async function (eleventyConfig) {
 	eleventyConfig.addPassthroughCopy({ 'static/fonts': 'fonts' })
 	eleventyConfig.addPassthroughCopy({ 'static/css': 'css' })
 	eleventyConfig.addPassthroughCopy({ 'static/js': 'js' })
+	eleventyConfig.addPassthroughCopy({
+	        'node_modules/microlighter/dist/microlighter.min.js':
+	                'js/microlighter/microlighter.min.js',
+	})
+	eleventyConfig.addPassthroughCopy({
+	        'node_modules/microlighter/dist/grammars/bash.js':
+	                'js/microlighter/grammars/bash.js',
+	})
+	eleventyConfig.addPassthroughCopy({
+	        'node_modules/microlighter/dist/grammars/css.js':
+	                'js/microlighter/grammars/css.js',
+	})
+	eleventyConfig.addPassthroughCopy({
+	        'node_modules/microlighter/dist/grammars/html.js':
+	                'js/microlighter/grammars/html.js',
+	})
+	eleventyConfig.addPassthroughCopy({
+	        'node_modules/microlighter/dist/grammars/javascript.js':
+	                'js/microlighter/grammars/javascript.js',
+	})
 	eleventyConfig.addPassthroughCopy({ 'static/robots.txt': 'robots.txt' })
 
 	if (process.env.ELEVENTY_ENV !== 'production') {
@@ -62,8 +81,6 @@ export default async function (eleventyConfig) {
 
 	// filter and sort nav items
 	eleventyConfig.addPlugin(eleventyNavigationPlugin)
-	// syntax highlighting
-	eleventyConfig.addPlugin(syntaxHighlight)
 
 	// pretty date
 	eleventyConfig.addFilter('prettyDate', dateObj =>

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -73,6 +73,7 @@
     <link rel="pingback" href="https://webmention.io/craveytrain.com/xmlrpc">
 
     <script type="module" src="/js/theme-toggle.js"></script>
+    <script type="module" src="/js/microlighter/microlighter.min.js"></script>
 </head>
 
 <body class="page-{{ page.fileSlug | slugify | default("home", true) }}">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
 			"version": "9.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"markdown-it": "^14.3.0"
+				"markdown-it": "^14.3.0",
+				"microlighter": "^2.1.0"
 			},
 			"devDependencies": {
 				"@11ty/eleventy": "^3.1.6",
 				"@11ty/eleventy-navigation": "^1.0.5",
 				"@11ty/eleventy-plugin-rss": "^3.0.0",
-				"@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
 				"@eslint/js": "^10.0.1",
 				"dotenv": "^17.4.2",
 				"eslint": "^10.7.0",
@@ -180,20 +180,6 @@
 				"@11ty/posthtml-urls": "^1.0.2",
 				"debug": "^4.4.3",
 				"posthtml": "^0.16.7"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/11ty"
-			}
-		},
-		"node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.2.tgz",
-			"integrity": "sha512-T6xVVRDJuHlrFMHbUiZkHjj5o1IlLzZW+1IL9eUsyXFU7rY2ztcYhZew/64vmceFFpQwzuSfxQOXxTJYmKkQ+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"prismjs": "^1.30.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -2391,6 +2377,15 @@
 			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
 			"license": "MIT"
 		},
+		"node_modules/microlighter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/microlighter/-/microlighter-2.1.0.tgz",
+			"integrity": "sha512-lngSOqDbT7IuNV1OekRp0zRCOlhVEuSdQdbEZbkXfmQPYpeIArk5wyrUQTvBmeCqiy/ZDW/RLmbopI74JBnCIg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/mime": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -2938,16 +2933,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/prettier/prettier?sponsor=1"
-			}
-		},
-		"node_modules/prismjs": {
-			"version": "1.30.0",
-			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
-			"integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/prr": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@11ty/eleventy": "^3.1.6",
 		"@11ty/eleventy-navigation": "^1.0.5",
 		"@11ty/eleventy-plugin-rss": "^3.0.0",
-		"@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
 		"@eslint/js": "^10.0.1",
 		"dotenv": "^17.4.2",
 		"eslint": "^10.7.0",
@@ -55,6 +54,7 @@
 		"sanitize-html": "^2.17.6"
 	},
 	"dependencies": {
-		"markdown-it": "^14.3.0"
+		"markdown-it": "^14.3.0",
+		"microlighter": "^2.1.0"
 	}
 }

--- a/scripts/wcag.py
+++ b/scripts/wcag.py
@@ -12,7 +12,7 @@ of role pairs, in both the jour (light) and nuit (dark) resolutions.
 
 Usage:
     python3 scripts/wcag.py               # validate static/css/main.css
-    python3 scripts/wcag.py --self-test    # validate the handoff palette
+    python3 scripts/wcag.py --self-test    # validate the reference palette
 
 Exit status: 0 if every pair passes its minimum, 1 otherwise (including
 the case where required tokens are not found in the CSS, that's expected
@@ -26,8 +26,8 @@ from pathlib import Path
 
 CSS_PATH = Path(__file__).resolve().parent.parent / "static" / "css" / "main.css"
 
-# The exact :root block from handoff/affiche-handoff.md, lines 124-164,
-# used by --self-test to validate the math independently of main.css.
+# A reference token block used by --self-test to validate the math
+# independently of main.css.
 SELF_TEST_CSS = """
 :root {
 	color-scheme: light dark;
@@ -47,6 +47,9 @@ SELF_TEST_CSS = """
 	--gold-bright: oklch(82% 0.11 85deg);
 	--teal: oklch(58% 0.08 200deg);
 	--teal-bright: oklch(63% 0.07 200deg);
+	--red-light: oklch(70% 0.15 30deg);
+	--teal-deep: oklch(45% 0.08 200deg);
+	--teal-light: oklch(70% 0.07 200deg);
 
 	/* -- Layer 2: semantic roles -- jour / nuit is only this remap -- */
 	--surface: light-dark(var(--cream), var(--midnight-deep));
@@ -64,6 +67,12 @@ SELF_TEST_CSS = """
 	--selection-bg: light-dark(var(--red), var(--red-bright));
 	--selection-fg: light-dark(var(--cream), var(--midnight-deep));
 	--footer-link: light-dark(var(--gold), var(--red));
+	--syntax-comment: light-dark(var(--midnight-light), var(--cream-dim));
+	--syntax-punctuation: light-dark(var(--midnight-light), var(--cream-dim));
+	--syntax-property: light-dark(var(--red), var(--red-light));
+	--syntax-value: light-dark(var(--midnight), var(--gold-bright));
+	--syntax-at-rule: light-dark(var(--teal-deep), var(--teal-light));
+	--syntax-selector: light-dark(var(--midnight), var(--gold-bright));
 }
 """
 
@@ -76,6 +85,12 @@ PAIRS = [
 	("--on-fill", "--fill", 4.5),
 	("--footer-link", "--fill", 4.5),
 	("--selection-fg", "--selection-bg", 4.5),
+	("--syntax-comment", "--surface-deep", 4.5),
+	("--syntax-punctuation", "--surface-deep", 4.5),
+	("--syntax-property", "--surface-deep", 4.5),
+	("--syntax-value", "--surface-deep", 4.5),
+	("--syntax-at-rule", "--surface-deep", 4.5),
+	("--syntax-selector", "--surface-deep", 4.5),
 ]
 
 PIGMENT_RE = re.compile(
@@ -226,7 +241,7 @@ def main():
 
 	if self_test:
 		root_block = extract_root_block(SELF_TEST_CSS)
-		exit_code = run(root_block, "SELF-TEST (handoff palette)")
+		exit_code = run(root_block, "SELF-TEST (reference palette)")
 		sys.exit(exit_code)
 
 	if not CSS_PATH.exists():

--- a/site/posts/git-svn-setup.md
+++ b/site/posts/git-svn-setup.md
@@ -34,7 +34,7 @@ You can probably gather that we are telling Git where the specific SVN structure
 
 Now, you will notice there is a .git folder in this location. Go into that folder and open the config file in the text editor of your choice. It may look something like this:
 
-```git
+```
 [svn-remote "svn"]
 	url = http://svnserver.yourdomain.tld
 	fetch = path/to/specific/project/Trunk:refs/remotes/appName/trunk
@@ -44,13 +44,13 @@ Now, you will notice there is a .git folder in this location. Go into that folde
 
 Now, that's great if you use the standard layout. If you have some variables, you may have to adjust this. For example, we use a directories under Branches for types of branches (Hotfix, Feature, etc). Git won't recursively look for branches in that directory so we have to adjust the config. The line we are looking for is below:
 
-```git
+```
 branches = path/to/specific/project/Branches/*:refs/remotes/appName/*
 ```
 
 So, for our config, I made a slight adjustment:
 
-```git
+```
 branches = path/to/specific/project/Branches/*/*:refs/remotes/appName/*
 ```
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -97,6 +97,9 @@ h6 {
 	--gold-bright: oklch(82% 0.11 85deg);
 	--teal: oklch(58% 0.08 200deg);
 	--teal-bright: oklch(63% 0.07 200deg);
+	--red-light: oklch(70% 0.15 30deg);
+	--teal-deep: oklch(45% 0.08 200deg);
+	--teal-light: oklch(70% 0.07 200deg);
 
 	/* ── Layer 2: semantic roles, jour / nuit is only this remap ── */
 	--surface: light-dark(var(--cream), var(--midnight-deep));
@@ -121,13 +124,13 @@ h6 {
 	--font-script: yellowtail, cursive;
 	--font-code: inconsolata, 'SFMono-Regular', consolas, monospace;
 
-	/* TODO(affiche): code-block/syntax palette pass, see DESIGN.md §9 */
-	--syntax-property: oklch(55% 0.18 40deg);
-	--syntax-value: oklch(45% 0.12 305deg);
-	--syntax-at-rule: oklch(52% 0.12 130deg);
-	--syntax-selector: oklch(25% 0.02 55deg);
-	--syntax-comment: oklch(64% 0.03 60deg);
-	--syntax-punctuation: oklch(64% 0.03 60deg);
+	/* Syntax */
+	--syntax-comment: light-dark(var(--midnight-light), var(--cream-dim));
+	--syntax-punctuation: light-dark(var(--midnight-light), var(--cream-dim));
+	--syntax-property: light-dark(var(--red), var(--red-light));
+	--syntax-value: light-dark(var(--midnight), var(--gold-bright));
+	--syntax-at-rule: light-dark(var(--teal-deep), var(--teal-light));
+	--syntax-selector: light-dark(var(--midnight), var(--gold-bright));
 
 	/* Layout */
 	--max-width: 1280px;

--- a/static/css/prose.css
+++ b/static/css/prose.css
@@ -162,78 +162,62 @@
 	border: none;
 }
 
-.post-content pre .token {
-	font-weight: 400;
-}
-
-/* TODO(affiche): code-block/syntax palette pass, see DESIGN.md §9 */
-.token.comment,
-.token.prolog,
-.token.doctype,
-.token.cdata {
+.post-content ::highlight(comment),
+.post-content ::highlight(quote) {
 	color: var(--syntax-comment);
 	font-style: italic;
 }
 
-.token.punctuation {
+.post-content ::highlight(operator),
+.post-content ::highlight(punctuation) {
 	color: var(--syntax-punctuation);
 }
 
-.token.property,
-.token.tag,
-.token.boolean,
-.token.number,
-.token.constant,
-.token.symbol,
-.token.deleted {
+.post-content ::highlight(numeric),
+.post-content ::highlight(boolean),
+.post-content ::highlight(constant),
+.post-content ::highlight(symbol),
+.post-content ::highlight(character-entity),
+.post-content ::highlight(anchor),
+.post-content ::highlight(entity),
+.post-content ::highlight(property),
+.post-content ::highlight(key),
+.post-content ::highlight(attribute-name),
+.post-content ::highlight(tag),
+.post-content ::highlight(inserted),
+.post-content ::highlight(deleted) {
 	color: var(--syntax-property);
 }
 
-.token.selector,
-.token.attr-name,
-.token.string,
-.token.char,
-.token.builtin,
-.token.inserted {
+.post-content ::highlight(string),
+.post-content ::highlight(regexp),
+.post-content ::highlight(attribute-value),
+.post-content ::highlight(link),
+.post-content ::highlight(raw) {
 	color: var(--syntax-at-rule);
 }
 
-.token.operator,
-.token.entity,
-.token.url,
-.language-css .token.string,
-.style .token.string {
+.post-content ::highlight(selector) {
 	color: var(--syntax-selector);
 }
 
-.token.atrule,
-.token.attr-value,
-.token.keyword {
+.post-content ::highlight(keyword),
+.post-content ::highlight(storage),
+.post-content ::highlight(at-rule),
+.post-content ::highlight(doctype),
+.post-content ::highlight(important),
+.post-content ::highlight(section) {
 	color: var(--syntax-value);
 }
 
-.token.function,
-.token.class-name {
-	color: var(--accent);
-}
-
-.token.regex,
-.token.important,
-.token.variable {
-	color: var(--accent);
-}
-
-.token.important,
-.token.bold {
-	font-weight: 600;
-}
-
-.token.italic {
-	font-style: italic;
-}
-
-.token.entity {
-	cursor: help;
+.post-content ::highlight(function),
+.post-content ::highlight(decorator),
+.post-content ::highlight(animation),
+.post-content ::highlight(type),
+.post-content ::highlight(support),
+.post-content ::highlight(variable),
+.post-content ::highlight(interpolation) {
+	color: var(--syntax-property);
 }
 
 /* ─── 7. Facepile ─── */


### PR DESCRIPTION
## Summary
- replace Eleventy’s Prism plugin with self-hosted MicroLighter runtime and only the grammars used by posts
- preserve the affiche theme with site-owned CSS Custom Highlight selectors and a dedicated jour/nuit syntax palette
- validate syntax contrast against the code surface and leave Git configuration examples as readable plain code

## Verification
- `npm run lint:ci`
- `npm run build`
- `python3 scripts/wcag.py`
- `python3 scripts/wcag.py --self-test`
- Playwright review of highlighted HTML, CSS, and JavaScript code in pinned jour and nuit